### PR TITLE
Support reading package tag from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The assumed use case in `in` is cache npm package into private registry.
 * `email`: *Required.* npm registry login email.
 * `path`: *Required.* Path to the package to be published. (including `package.json`) 
 * `tag`: *Optional.* package tag.
+* `tag_file`: *Optional.* Path to the file in which to read the package tag from.
 
 ## Pipeline example
 

--- a/out/command.go
+++ b/out/command.go
@@ -1,6 +1,10 @@
 package out
 
 import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
 	"github.com/idahobean/npm-resource"
 	"github.com/idahobean/npm-resource/npm"
 )
@@ -26,9 +30,14 @@ func (command *Command) Run(request Request) (Response, error) {
 		return Response{}, err
 	}
 
+	tag, err := tagFrom(request.Params)
+	if err != nil {
+		return Response{}, err
+	}
+
 	err = command.packageManager.Publish(
 		request.Params.Path,
-		request.Params.Tag,
+		tag,
 		request.Source.Registry,
 	)
 	if err != nil {
@@ -65,4 +74,17 @@ func (command *Command) Run(request Request) (Response, error) {
 			},
 		},
 	}, nil
+}
+
+func tagFrom(params Params) (string, error) {
+	if len(params.TagFile) == 0 {
+		return params.Tag, nil
+	}
+
+	t, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", os.Args[1], params.TagFile))
+	if err != nil {
+		return "", err
+	}
+
+	return string(t), nil
 }

--- a/out/models.go
+++ b/out/models.go
@@ -13,6 +13,7 @@ type Params struct {
 	Email    string `json:"email"`
 	Path     string `json:"path"`
 	Tag      string `json:"tag"`
+	TagFile  string `json:"tag_file"`
 }
 
 type Response struct {


### PR DESCRIPTION
We've been investigating the usage of Concourse to push modules up to the NPM public registry, and thought this would be a good resource to start with. The one use-case we required was to dynamically pull tags that are generated from prior-tasks in our build jobs. I've plumbed in the logic to support reading a tag value from a configurable file, and it appears to working OK within our pipelines.

I've setup your pipeline locally and the tests seem to be passing. I understand there is a lack of tests covering the new functionality in this PR, but I wanted to open it early to see if you had any feedback, and if you are willing to support this option.